### PR TITLE
correct probleme : PHP Fatal error:  Declaration of Mojo\Sonata\UIBundle...

### DIFF
--- a/Block/AddressBlock.php
+++ b/Block/AddressBlock.php
@@ -10,7 +10,7 @@ namespace Mojo\Sonata\UIBundle\Block;
 
 use Mojo\Sonata\UIBundle\Entity\SimpleDataManagerInterface;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;

--- a/Block/CarouselBlock.php
+++ b/Block/CarouselBlock.php
@@ -9,7 +9,7 @@
 namespace Mojo\Sonata\UIBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;

--- a/Block/HeaderBlock.php
+++ b/Block/HeaderBlock.php
@@ -3,7 +3,7 @@
 namespace Mojo\Sonata\UIBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;

--- a/Block/PostBlock.php
+++ b/Block/PostBlock.php
@@ -9,7 +9,7 @@
 namespace Mojo\Sonata\UIBundle\Block;
 
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;

--- a/Block/SimpleDataBlock.php
+++ b/Block/SimpleDataBlock.php
@@ -10,7 +10,7 @@ namespace Mojo\Sonata\UIBundle\Block;
 
 use Mojo\Sonata\UIBundle\Entity\SimpleDataManagerInterface;
 use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\AdminBundle\Validator\ErrorElement;
+use Sonata\CoreBundle\Validator\ErrorElement;
 use Sonata\BlockBundle\Block\BaseBlockService;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Model\BlockInterface;


### PR DESCRIPTION
With new version of Sonata the namespace of ErrorElement was changed
this pull request will correct the error : 
PHP Fatal error:  Declaration of Mojo\Sonata\UIBundle\Block\PostBlock::validateBlock() must be compatible with Sonata\BlockBundle\Block\BlockAdminServiceInterface::validateBlock(Sonata\CoreBundle\Validator\ErrorElement $errorElement, Sonata\BlockBundle\Model\BlockInterface $block)